### PR TITLE
 Removed old links and notes related to class components

### DIFF
--- a/prep-for-module-3-frontend.markdown
+++ b/prep-for-module-3-frontend.markdown
@@ -87,12 +87,11 @@ Please update your LinkedIn profiles with...
 Here are some additional resources:
 
 - Take a deeper dive into JSX with the [React docs](https://react.dev/learn/javascript-in-jsx-with-curly-braces) and this [tutorial](https://flaviocopes.com/jsx/)
-- Take a look at some extra [Testing with Fun Fun Function](https://www.youtube.com/playlist?list=PL0zVEGEvSaeF_zoW9o66wa_UCNE3a7BEr) (This is a playlist of 7 YouTube videos on testing)
+- Take a look at the [Cypress](https://docs.cypress.io/guides/core-concepts/introduction-to-cypress). We will be utilizing end-to-end testing in M3 to test our React applications.
 - [Shop Talk with Tom Dale](http://shoptalkshow.com/episodes/147-tom-dale/) (This one is a bit older but still a good introduction for thinking about why client-side applications are important and what frameworks bring to the table.)
 - [Intro to JS Modules](https://tylermcginnis.com/javascript-modules-iifes-commonjs-esmodules/) (Ever been confused about `module.exports` vs `export default`? When to use `import` vs `require(`? Read this for some clarity. This article provides a clear explanation of when to use export default import/export. Although you may find some class components in the article, we've shared it with you because it effectively explains when to use each method.)
-
+- We will have code challenges during M3 to prepare you for your interviews. If you have time, make sure to visit [Codewars](https://www.codewars.com/) and work on challenges with a 6 or 7 ranking.
 - [NPM Refresher](https://ui.dev/npm/) (We're going to be using a lot of packages, make sure you're comfortable with your package manager!)
-- [Wes Bos JavaScript30](https://javascript30.com) (Maybe pick 5 or 10 exercises - try to challenge yourself)
 - [100 Days of CSS challenge](https://100dayscss.com/) (Do a few days of challenges to keep your CSS skills sharp)
 - Watch [this video](https://www.youtube.com/watch?v=eesqK59rhGA) on details of the request/response cycle.
 - Read [Fetching data with Effects](https://react.dev/reference/react/useEffect#fetching-data-with-effects) to learn about incorporating network requests in React apps.

--- a/prep-for-module-3-frontend.markdown
+++ b/prep-for-module-3-frontend.markdown
@@ -10,9 +10,9 @@
 There are a bunch of JavaScript frameworks out there to use. At Turing, we choose to teach **React** - it's one of the most popular frameworks out there. Actually, a lot of developers will call React a library, which it is...but it can also be described as a framework. It's a little confusing, but the lines are blurred for React. Let's just say that React is a library with some rules and conventions to follow.
 
 Complete **one** of the tutorials below to get introduced to React:
-* [Tyler McGinnis's React Tutorial: A Comprehensive Guide to learning React.js in 2018](https://ui.dev/react-hooks)
+* [Original Scrimba React Course](https://scrimba.com/playlist/p7P5Hd) - In M3, the initial focus will be on learning functional components and the utilization of hooks. Therefore, start by watching the Hooks portion of this lesson.
 * [React tutorial from the docs](https://react.dev/learn/tutorial-tic-tac-toe)
-* [Original Scrimba React Course](https://scrimba.com/learn/learnreact) - In M3 the initial focus will be on learning functional components and the utilization of hooks.
+* [Hooks Scrimba React Course](https://scrimba.com/learn/learnreact) - In M3 the initial focus will be on learning functional components and the utilization of hooks.
 * Optional: practice building a simple app in React. Think of a mod 1 project, and build that in React! We strongly encourage you to spin up a React app with [Create React App](https://create-react-app.dev/) and play around with it!
 
 
@@ -68,7 +68,9 @@ Create a GitHub gist to answer these questions in as much detail as possible. Im
 * What is React "state?"
 * What does "data down, actions up" mean in React?
 
-_Note:_ As you do your research, be aware that if you come across tutorials discussing class components, they may be related to older versions of React. We used to rely on class components before hooks were introduced. We _will_ be learning hooks in Mod 3, and they are now the more modern and recommended approach.  
+_Note:_ As you do your research, be aware that if you come across tutorials discussing class components, they may be related to older versions of React.It's important to note that it's still very possible that you will run into class-based React components in legacy code on the job.
+We used to rely on class components before hooks were introduced. We _will_ be learning hooks in Mod 3, and they are now the more modern and recommended approach. 
+
 **By 5PM on Friday of intermission, send a link to your gist in a DM to _both_ of your instructors.**
 
 ### 2. LinkedIn Updates *(required)*
@@ -86,7 +88,7 @@ Please update your LinkedIn profiles with...
 
 Here are some additional resources:
 
-- Take a deeper dive into JSX with the [React docs](https://react.dev/learn/javascript-in-jsx-with-curly-braces) and this [tutorial](https://flaviocopes.com/jsx/)
+- Take a deeper dive into JSX with the [React docs](https://react.dev/learn/javascript-in-jsx-with-curly-braces) and this [article](https://flaviocopes.com/jsx/)
 - Take a look at the [Cypress](https://docs.cypress.io/guides/core-concepts/introduction-to-cypress). We will be utilizing end-to-end testing in M3 to test our React applications.
 - [Shop Talk with Tom Dale](http://shoptalkshow.com/episodes/147-tom-dale/) (This one is a bit older but still a good introduction for thinking about why client-side applications are important and what frameworks bring to the table.)
 - [Intro to JS Modules](https://tylermcginnis.com/javascript-modules-iifes-commonjs-esmodules/) (Ever been confused about `module.exports` vs `export default`? When to use `import` vs `require(`? Read this for some clarity. This article provides a clear explanation of when to use export default import/export. Although you may find some class components in the article, we've shared it with you because it effectively explains when to use each method.)

--- a/prep-for-module-3-frontend.markdown
+++ b/prep-for-module-3-frontend.markdown
@@ -10,11 +10,10 @@
 There are a bunch of JavaScript frameworks out there to use. At Turing, we choose to teach **React** - it's one of the most popular frameworks out there. Actually, a lot of developers will call React a library, which it is...but it can also be described as a framework. It's a little confusing, but the lines are blurred for React. Let's just say that React is a library with some rules and conventions to follow.
 
 Complete **one** of the tutorials below to get introduced to React:
-* [Tyler McGinnis's React Tutorial: A Comprehensive Guide to learning React.js in 2018](https://tylermcginnis.com/reactjs-tutorial-a-comprehensive-guide-to-building-apps-with-react/)
-* [React tutorial from the docs](https://reactjs.org/tutorial/tutorial.html)
-* [Original Scrimba React Course](https://scrimba.com/playlist/p7P5Hd)
+* [Tyler McGinnis's React Tutorial: A Comprehensive Guide to learning React.js in 2018](https://ui.dev/react-hooks)
+* [React tutorial from the docs](https://react.dev/learn/tutorial-tic-tac-toe)
+* [Original Scrimba React Course](https://scrimba.com/learn/learnreact) - In M3 the initial focus will be on learning functional components and the utilization of hooks.
 * Optional: practice building a simple app in React. Think of a mod 1 project, and build that in React! We strongly encourage you to spin up a React app with [Create React App](https://create-react-app.dev/) and play around with it!
-<!-- * [Updated Scrimba React Course](https://scrimba.com/learn/learnreact) -->
 
 
 ### Testing paradigms
@@ -26,7 +25,9 @@ We are going to learn a new type of testing! In Mods 1 and 2, you learned about 
 * Practice writing user stories by creating some user stories for a Mod 2 or Mod 1 project
 
 ### Destructuring
-Destructuring is a helpful "shortcut" in JavaScript, and it's common to see it in React Code. While you'll never be *required* to use destructuring, you should definitely be able to work with it and understand how it works.   
+
+Destructuring is a helpful "shortcut" in JavaScript, and it's common to see it in React Code. While you'll never be *required* to use destructuring, you should definitely be able to work with it and understand how it works.
+
 * Walk through [this lesson](https://frontend.turing.edu/lessons/module-2/intro-to-destructuring.html)
 
 ### Workflow
@@ -55,6 +56,7 @@ xcode-select --install
 ## Deliverables 
 
 ### 1. React Review *(required)*
+
 Create a GitHub gist to answer these questions in as much detail as possible. Imagine someone is asking these questions in an interview (these are popular interview questions).
 
 * What is a "data model", and how does it relate to the DOM in a front-end application?
@@ -66,12 +68,13 @@ Create a GitHub gist to answer these questions in as much detail as possible. Im
 * What is React "state?"
 * What does "data down, actions up" mean in React?
 
-_Note:_ As you do your research, stay away from React articles that talk exclusively about "hooks". We _will_ be learning hooks in Mod 3 but they are not a requirement for success in the module.
-
+_Note:_ As you do your research, be aware that if you come across tutorials discussing class components, they may be related to older versions of React. We used to rely on class components before hooks were introduced. We _will_ be learning hooks in Mod 3, and they are now the more modern and recommended approach.  
 **By 5PM on Friday of intermission, send a link to your gist in a DM to _both_ of your instructors.**
 
 ### 2. LinkedIn Updates *(required)*
+
 Please update your LinkedIn profiles with...  
+
 * additional skills that you’ve learned since Mod 1
 * ensure you have technical keywords in your About Me professional story
 * take “student” out of your headline if it’s there 
@@ -83,13 +86,14 @@ Please update your LinkedIn profiles with...
 
 Here are some additional resources:
 
-- Take a deeper dive into JSX with the [React docs](https://reactjs.org/docs/introducing-jsx.html) and this [tutorial](https://flaviocopes.com/jsx/)
-- Take a look at some extra [JSX gotchas (courtesy of tyler McGinnis)](https://ui.dev/jsx/)- [Testing with Fun Fun Function](https://www.youtube.com/playlist?list=PL0zVEGEvSaeF_zoW9o66wa_UCNE3a7BEr) (This is a playlist of 7 YouTube videos on testing)
+- Take a deeper dive into JSX with the [React docs](https://react.dev/learn/javascript-in-jsx-with-curly-braces) and this [tutorial](https://flaviocopes.com/jsx/)
+- Take a look at some extra [Testing with Fun Fun Function](https://www.youtube.com/playlist?list=PL0zVEGEvSaeF_zoW9o66wa_UCNE3a7BEr) (This is a playlist of 7 YouTube videos on testing)
 - [Shop Talk with Tom Dale](http://shoptalkshow.com/episodes/147-tom-dale/) (This one is a bit older but still a good introduction for thinking about why client-side applications are important and what frameworks bring to the table.)
-- [Intro to JS Modules](https://tylermcginnis.com/javascript-modules-iifes-commonjs-esmodules/) (Ever been confused about `module.exports` vs `export default`? When to use `import` vs `require()`? Read this for some clarity)
-- [NPM Refresher](https://ui.dev/npm/) (We're going to be using a lot of packages, make sure you're comfortable with your pakcage manager!)
+- [Intro to JS Modules](https://tylermcginnis.com/javascript-modules-iifes-commonjs-esmodules/) (Ever been confused about `module.exports` vs `export default`? When to use `import` vs `require(`? Read this for some clarity. This article provides a clear explanation of when to use export default import/export. Although you may find some class components in the article, we've shared it with you because it effectively explains when to use each method.)
+
+- [NPM Refresher](https://ui.dev/npm/) (We're going to be using a lot of packages, make sure you're comfortable with your package manager!)
 - [Wes Bos JavaScript30](https://javascript30.com) (Maybe pick 5 or 10 exercises - try to challenge yourself)
 - [100 Days of CSS challenge](https://100dayscss.com/) (Do a few days of challenges to keep your CSS skills sharp)
 - Watch [this video](https://www.youtube.com/watch?v=eesqK59rhGA) on details of the request/response cycle.
-- Read [ajax in react](https://reactjs.org/docs/faq-ajax.html) to learn about incorporating network requests in React apps.
+- Read [Fetching data with Effects](https://react.dev/reference/react/useEffect#fetching-data-with-effects) to learn about incorporating network requests in React apps.
 - Watch [this video](https://www.youtube.com/watch?v=8aGhZQkoFbQ) on the event loop.


### PR DESCRIPTION
This PR addressed issue https://github.com/turingschool/front-end-curriculum/issues/637

### Changes Requested in Issue:

The current prework has multiple links to the old react docs, and examples showing class-based components
These links should be updated to either more up to date alternatives, or removed entirely if they are no longer relevant
Confer with the current M3 team as to any additional resources that should be added or removed

### Changes Made:

- [x] Removed all the old links that was linked to the old React Docs
- [x] All links have been updated, but I've left a few links out to consult with the M3 team in case they are no longer relevant. Please refer to the question section for details.
- [ ] Confer with the current M3 team as to any additional resources that should be added or removed

### Question:

I'm unsure whether to keep these three links in our intermission work, as they are dated and I don't know if they're still helpful or if students even refer to them.See below 

- Take a look at some extra [Testing with Fun Fun Function](https://www.youtube.com/playlist?list=PL0zVEGEvSaeF_zoW9o66wa_UCNE3a7BEr) (This is a playlist of 7 YouTube videos on testing) - this is about unit testing
- [Shop Talk with Tom Dale](http://shoptalkshow.com/episodes/147-tom-dale/) (This one is a bit older but still a good introduction for thinking about why client-side applications are important and what frameworks bring to the table.) - This one is dated too but I think it's still relevant. 
-  [Wes Bos JavaScript30](https://javascript30.com) (Maybe pick 5 or 10 exercises - try to challenge yourself) - This resource is dated but contains some valuable JavaScript exercises. Instead of including this link, perhaps we could provide a link to CodeWars for more up-to-date and engaging practice opportunities?
